### PR TITLE
[#4] Rework tailored facades

### DIFF
--- a/src/FacadeDefinition.php
+++ b/src/FacadeDefinition.php
@@ -2,8 +2,11 @@
 
 use BapCat\Phi\Ioc;
 use BapCat\Propifier\PropifierTrait;
+use BapCat\Values\Regex;
+use BapCat\Values\Text;
 
 use ReflectionClass;
+use ReflectionException;
 
 /**
  * @property-read  string  $name
@@ -56,13 +59,77 @@ class FacadeDefinition {
 
   /**
    * @return  array
+   *
+   * @throws  ReflectionException
    */
   public function toArray(): array {
+    $reflect = new ReflectionClass($this->binding);
+    $methods = [];
+    $imports = [];
+
+    $throwsRegex = new Regex('/@throws\s+([^\\ ]+)\s/');
+    $useStatementParser = new UseStatementParser();
+
+    foreach($reflect->getMethods() as $method) {
+      if($method->isPublic() && !($method->isConstructor() || $method->isDestructor() || strpos($method->getName(), '__') === 0)) {
+        $methods[] = $method;
+
+        foreach($method->getParameters() as $param) {
+          if($param->getType() !== null && !$param->getType()->isBuiltin()) {
+            $imports[] = $param->getType()->getName();
+          }
+        }
+
+        if($method->hasReturnType() && !$method->getReturnType()->isBuiltin()) {
+          $imports[] = $method->getReturnType()->getName();
+        }
+
+        if($method->getDocComment() !== false) {
+          foreach($throwsRegex->capture(new Text($method->getDocComment())) as $exception) {
+            $exception = trim((string)reset($exception));
+
+            $methodImports = $useStatementParser->parseUseStatements($method->getDeclaringClass());
+            $found = false;
+
+            foreach($methodImports as $methodImport) {
+              if(substr_compare($methodImport, $exception, -strlen($exception)) === 0) {
+                $found = true;
+                $imports[] = $methodImport;
+                break;
+              }
+            }
+
+            if(!$found) {
+              $imports[] = $method->getDeclaringClass()->getNamespaceName() . '\\' . $exception;
+            }
+          }
+        }
+      }
+    }
+
+    $imports = array_unique($imports);
+    $imports = array_filter($imports, function($import) {
+      // Don't add import if the import has the same class name as the facade (TODO: this is not ideal...)
+      if(substr_compare($import, $this->name, -strlen($this->name)) === 0) {
+        return false;
+      }
+
+      // Don't add imports for classes in the global namespace since facades are generated in the global namespace
+      if(strpos($import, '\\') === false) {
+        return false;
+      }
+
+      // Only add imports that actually exist
+      return class_exists($import) || interface_exists($import);
+    });
+
     return [
       'name'    => $this->name,
       'binding' => $this->binding,
       'ioc'     => get_class($this->ioc),
-      'reflect' => new ReflectionClass($this->ioc->resolve($this->binding)),
+      'reflect' => new ReflectionClass($this->binding),
+      'methods' => $methods,
+      'imports' => $imports,
     ];
   }
 }

--- a/src/TokenParser.php
+++ b/src/TokenParser.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace BapCat\Facade;
+
+/**
+ * Parses a file for namespaces/use/class declarations.
+ *
+ * Class taken and adapted from doctrine/annotations to avoid pulling the whole package.  Then taken again to avoid pulling in PHP-DI/PhpDocReader.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Christian Kaps <christian.kaps@mohiva.com>
+ */
+class TokenParser {
+
+  /**
+   * The token list.
+   *
+   * @var array
+   */
+  private $tokens;
+
+  /**
+   * The number of tokens.
+   *
+   * @var int
+   */
+  private $numTokens;
+
+  /**
+   * The current array pointer.
+   *
+   * @var int
+   */
+  private $pointer = 0;
+
+  /**
+   * @param string $contents
+   */
+  public function __construct($contents) {
+    $this->tokens = token_get_all($contents);
+    // The PHP parser sets internal compiler globals for certain things. Annoyingly, the last docblock comment it
+    // saw gets stored in doc_comment. When it comes to compile the next thing to be include()d this stored
+    // doc_comment becomes owned by the first thing the compiler sees in the file that it considers might have a
+    // docblock. If the first thing in the file is a class without a doc block this would cause calls to
+    // getDocBlock() on said class to return our long lost doc_comment. Argh.
+    // To workaround, cause the parser to parse an empty docblock. Sure getDocBlock() will return this, but at least
+    // it's harmless to us.
+    token_get_all("<?php\n/**\n *\n */");
+    $this->numTokens = count($this->tokens);
+  }
+
+  /**
+   * Gets all use statements.
+   *
+   * @param string $namespaceName The namespace name of the reflected class.
+   *
+   * @return array A list with all found use statements.
+   */
+  public function parseUseStatements($namespaceName) {
+    $statements = [];
+    while ( ( $token = $this->next() ) ) {
+
+      if ( $token[0] === T_USE ) {
+        $statements = array_merge($statements, $this->parseUseStatement());
+        continue;
+      }
+
+      if ( $token[0] !== T_NAMESPACE || $this->parseNamespace() != $namespaceName ) {
+        continue;
+      }
+
+      // Get fresh array for new namespace. This is to prevent the parser to collect the use statements
+      // for a previous namespace with the same name. This is the case if a namespace is defined twice
+      // or if a namespace with the same name is commented out.
+      $statements = [];
+    }
+
+    return $statements;
+  }
+
+  /**
+   * Gets the next non whitespace and non comment token.
+   *
+   * @param boolean $docCommentIsComment If TRUE then a doc comment is considered a comment and skipped.
+   *                                     If FALSE then only whitespace and normal comments are skipped.
+   *
+   * @return array|null The token if exists, null otherwise.
+   */
+  private function next($docCommentIsComment = true) {
+    for ( $i = $this->pointer; $i < $this->numTokens; $i++ ) {
+      $this->pointer++;
+
+      if ( $this->tokens[$i][0] === T_WHITESPACE || $this->tokens[$i][0] === T_COMMENT || ( $docCommentIsComment && $this->tokens[$i][0] === T_DOC_COMMENT ) ) {
+        continue;
+      }
+
+      return $this->tokens[$i];
+    }
+
+    return null;
+  }
+
+  /**
+   * Parses a single use statement.
+   *
+   * @return array A list with all found class names for a use statement.
+   */
+  private function parseUseStatement() {
+    $class = '';
+    $alias = '';
+    $statements = [];
+    $explicitAlias = false;
+
+    while ( ( $token = $this->next() ) ) {
+      $isNameToken = $token[0] === T_STRING || $token[0] === T_NS_SEPARATOR;
+      if ( !$explicitAlias && $isNameToken ) {
+        $class .= $token[1];
+        $alias = $token[1];
+      } elseif ( $explicitAlias && $isNameToken ) {
+        $alias .= $token[1];
+      } elseif ( $token[0] === T_AS ) {
+        $explicitAlias = true;
+        $alias = '';
+      } elseif ( $token === ',' ) {
+        $statements[strtolower($alias)] = $class;
+        $class = '';
+        $alias = '';
+        $explicitAlias = false;
+      } elseif ( $token === ';' ) {
+        $statements[strtolower($alias)] = $class;
+        break;
+      } else {
+        break;
+      }
+    }
+
+    return $statements;
+  }
+
+  /**
+   * Gets the namespace.
+   *
+   * @return string The found namespace.
+   */
+  private function parseNamespace() {
+    $name = '';
+
+    while ( ( $token = $this->next() ) && ( $token[0] === T_STRING || $token[0] === T_NS_SEPARATOR ) ) {
+      $name .= $token[1];
+    }
+
+    return $name;
+  }
+}

--- a/src/UseStatementParser.php
+++ b/src/UseStatementParser.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace BapCat\Facade;
+
+use SplFileObject;
+
+/**
+ * Parses a file for "use" declarations.
+ *
+ * Class taken and adapted from doctrine/annotations to avoid pulling the whole package.  Then taken again to avoid pulling in PHP-DI/PhpDocReader.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Christian Kaps <christian.kaps@mohiva.com>
+ */
+class UseStatementParser {
+  /**
+   * @return array A list with use statements in the form (Alias => FQN).
+   */
+  public function parseUseStatements(\ReflectionClass $class) {
+    if ( false === $filename = $class->getFilename() ) {
+      return [];
+    }
+
+    $content = $this->getFileContent($filename, $class->getStartLine());
+    if ( null === $content ) {
+      return [];
+    }
+
+    $namespace = preg_quote($class->getNamespaceName());
+    $content = preg_replace('/^.*?(\bnamespace\s+' . $namespace . '\s*[;{].*)$/s', '\\1', $content);
+    $tokenizer = new TokenParser('<?php ' . $content);
+    $statements = $tokenizer->parseUseStatements($class->getNamespaceName());
+    return $statements;
+  }
+
+  /**
+   * Gets the content of the file right up to the given line number.
+   *
+   * @param string  $filename   The name of the file to load.
+   * @param integer $lineNumber The number of lines to read from file.
+   *
+   * @return string The content of the file.
+   */
+  private function getFileContent($filename, $lineNumber) {
+    if ( !is_file($filename) ) {
+      return null;
+    }
+
+    $content = '';
+    $lineCnt = 0;
+    $file = new SplFileObject($filename);
+
+    while ( !$file->eof() ) {
+      if ( $lineCnt++ == $lineNumber ) {
+        break;
+      }
+
+      $content .= $file->fgets();
+    }
+
+    return $content;
+  }
+}

--- a/test-facade
+++ b/test-facade
@@ -4,10 +4,8 @@
 require __DIR__ . '/vendor/autoload.php';
 
 use BapCat\Facade\FacadeRegistry;
-use BapCat\Interfaces\Ioc\Ioc;
 use BapCat\Persist\Drivers\Local\LocalDriver;
 use BapCat\Phi\Phi;
-use BapCat\Values\ClassName;
 
 $ioc = Phi::instance();
 
@@ -34,4 +32,4 @@ HelloFacade::hello();
 var_dump(HelloFacade::HELLO);
 
 //TODO
-    // Temporary workaround; nom grabs onto the first end parenthesis
+// Temporary workaround; nom grabs onto the first end parenthesis


### PR DESCRIPTION
The facade generator will now attempt to restructure parameters and return types, and resolve `@inheritdoc` annotations upwards. Rather than simply using variadic arrays and unpacking them when sending to the wrapped method, it will build facade methods with matching signatures.